### PR TITLE
Add serializers inheritance support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open('README.md').read()
 
 setup(
     name="pycereal",
-    version='1.0',
+    version='1.1',
     packages=["cereal"],
     include_package_data=True,
     description="A simple object and Django model JSON serializer",

--- a/tests/test_class_serializer.py
+++ b/tests/test_class_serializer.py
@@ -11,7 +11,11 @@ logger = logging.getLogger('cereal.tests')
 
 
 @pytest.fixture
-def instance(id_=None):
+def instance():
+    return new_instance()
+
+
+def new_instance(id_=None):
     obj = JustAClass()
     obj.id = id_ or random.randint(1, 1024)
     obj.title = 'A Title'
@@ -28,6 +32,16 @@ class ClassSerializer(cereal.Serializer):
 
     def serialize_title(self, obj):
         return obj.title.upper()
+
+
+class DerivedClassSerializer(ClassSerializer):
+    exclude = ('id',)
+    content = cereal.Field()
+    updated = cereal.Field()
+
+
+class ClonedClassSerializer(ClassSerializer):
+    pass
 
 
 class JustAClass():
@@ -52,8 +66,28 @@ def test_datetime(instance):
 
 
 def test_serialize_list():
-    obj1 = instance(1)
-    obj2 = instance(2)
+    obj1 = new_instance(1)
+    obj2 = new_instance(2)
     data = ClassSerializer().serialize([obj1, obj2], raw=True)
     assert data[0]['id'] == obj1.id
     assert data[1]['id'] == obj2.id
+
+
+def test_serializer_inheritance(instance):
+    dt = datetime.datetime.now()
+    instance.updated = dt
+    data = DerivedClassSerializer().asdict_(instance)
+    assert 'A TITLE' == data['title']
+    assert 'jk not a post' == data['content']
+    assert dt.isoformat() == data['updated']
+
+
+def test_inheritance_override_exclude(instance):
+    data = DerivedClassSerializer().asdict_(instance)
+    assert 'id' not in data
+
+
+def test_inheritance_exclude_from_parent(instance):
+    data = ClonedClassSerializer().asdict_(instance)
+    assert 'content' not in data
+

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -12,7 +12,7 @@ logger = logging.getLogger('cereal.tests')
 
 @pytest.fixture
 def post():
-    return Post(title='A Title', content='jk not a post')
+    return Post(id=1, title='A Title', content='jk not a post')
 
 
 class PostSerializer(cereal.Serializer):
@@ -25,6 +25,17 @@ class PostSerializer(cereal.Serializer):
 
     def serialize_title(self, obj):
         return obj.title.upper()
+
+
+class RestrictedPostSerializer(PostSerializer):
+    exclude = ('content',)
+
+    class Meta:
+        model = Post
+
+
+class ClonedPostSerializer(PostSerializer):
+    pass
 
 
 def test_exclude(post):
@@ -42,3 +53,24 @@ def test_datetime(post):
     post.created = dt
     data = PostSerializer().asdict_(post)
     assert dt.isoformat() == data['created']
+
+
+def test_model_serializer_inheritance(post):
+    data = RestrictedPostSerializer().asdict_(post)
+    assert 'A TITLE' == data['title']
+
+
+def test_inheritance_override_exclude(post):
+    data = RestrictedPostSerializer().asdict_(post)
+    assert 'content' not in data
+    assert 1 == data['id']
+
+
+def test_inheritance_exclude_from_parent(post):
+    data = ClonedPostSerializer().asdict_(post)
+    assert 'id' not in data
+
+
+def test_inheritance_Meta_from_parent(post):
+    data = ClonedPostSerializer().asdict_(post)
+    assert 'A TITLE' == data['title']


### PR DESCRIPTION
@jcarbaugh Not sure if you are accepting pull requests or still maintaining this. 
This is the use case that led to this PR:
I have a Customer Django model and I need two different serializers for it, like so
```
class CustomerSerializer(cereal.Serializer):
    merchant = cereal.Field()

    exclude = (
        'field1', 'field2', 'field3'
    )

    def serialize_merchant(self, customer):
        return "a merchant"

    class Meta:
        model = Customer


class AnotherCustomerSerializer(CustomerSerializer):
    exclude = (
        'field1', field2', 'field3', 'field4', 'field5',
        'field6', field7', 'field8', 'field9'
    )
```
However, the merchant field is not present in `AnotherCustomerSerializer`. Same thing happens with the Meta cls and exclude if I don't override it.

Let me know what you think.

If you are no longer maintaining it I'd be happy to take a crack at it. 